### PR TITLE
Add rules page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ races/
 leaderboard.txt
 public/index.html
 public/racelist.html
-public/resources.html
 public/rasyncs.html
+public/resources.html
+public/rules.html
 public/weights.html

--- a/generate_html.py
+++ b/generate_html.py
@@ -8,6 +8,7 @@ def generate_website(leaderboard, unqualed, racelist):
     generated_rated_asyncs(racelist)
     generate_html_weights()
     generate_resources()
+    generate_rules()
 
 
 def generate_html_leaderboard(leaderboard, unqualed):
@@ -108,6 +109,24 @@ def generate_resources():
 
         # Write the body
         with open("html_templates/resource_body.html", 'r') as fin:
+            body = fin.read()
+        fp.write(body)
+
+        # Close out tags
+        with open("html_templates/closeout.html", 'r') as fin:
+            footer = fin.read()
+        fp.write(footer)
+
+
+def generate_rules():
+    with open("public/rules.html", 'w') as fp:
+        # Write the header
+        with open("html_templates/preamble.html", 'r') as fin:
+            header = fin.read()
+        fp.write(header)
+
+        # Write the body
+        with open("html_templates/rules_body.html", 'r') as fin:
             body = fin.read()
         fp.write(body)
 

--- a/html_templates/preamble.html
+++ b/html_templates/preamble.html
@@ -11,7 +11,8 @@
         <li><a href="racelist">Race List</a></li>
         <li><a href="rasyncs">Rated Asyncs</a></li>
         <li><a href="weights">Weights</a></li>
-        <li style="float:right"><a href="resources">Resources</a></li>
+        <li class="right"><a href="resources">Resources</a></li>
+        <li class="right"><a href="rules">Rules</a></li>
     </ul>
 </header>
 <main>

--- a/html_templates/rules_body.html
+++ b/html_templates/rules_body.html
@@ -1,17 +1,18 @@
 <div class="player-table">
     <span class="table-header"><h4>Rules</h4></span>
     <ol class="rules">
-    <li>You must use the <a href="https://github.com/matthewkirby/plando-random-settings/releases/latest">most recent version</a> of the RSL script. (Seeds rolled by RSLBot are always on the most recent version.)</li>
-    <li>You must ping <tt>@Random Settings</tt> in the OoTR Discord and have your race open to all participants.</li>
-    <li>Follow the <a href="https://wiki.ootrandomizer.com/index.php?title=Rules#Universal_Rules">Universal Rules</a> and the <a href="https://wiki.ootrandomizer.com/index.php?title=Standard">Standard</a> ruleset, with a few exceptions listed below:</li>
-    <li>Crossing the Gerudo Valley bridge as a child shall be banned unless it is from back to front.</li>
-    <li>Crossing the Gerudo Valley bridge as an adult shall be banned unless the bridge itself is repaired, or you have Epona or Longshot.</li>
-    <li>Child in Gerudo Fortress is unbanned in all circumstances.</li>
-    <li>Timing will end differently based on the gamemode:
-        <ol>
-            <li>If it is a “Beat Ganon” seed, standard timing rules apply; .done is on the first frame of the cutscene that plays after beating Ganon.</li>
-            <li>If it is a “Triforce Hunt” seed, .done will be on the first frame the game fades completely to black after obtaining the last required piece.</li>
-        </ol>
-    </li>
-</ol>
+        <li>You must use the <a href="https://github.com/matthewkirby/plando-random-settings/releases/latest">most recent version</a> of the RSL script. (Seeds rolled by RSLBot are always on the most recent version.)</li>
+        <li>You must ping <tt>@Random Settings</tt> in the OoTR Discord and have your race open to all participants.</li>
+        <li>Follow the <a href="https://wiki.ootrandomizer.com/index.php?title=Rules#Universal_Rules">Universal Rules</a> and the <a href="https://wiki.ootrandomizer.com/index.php?title=Standard">Standard</a> ruleset, with a few exceptions listed below:</li>
+        <li>Crossing the Gerudo Valley bridge as a child shall be banned unless it is from back to front.</li>
+        <li>Crossing the Gerudo Valley bridge as an adult shall be banned unless the bridge itself is repaired, or you have Epona or Longshot.</li>
+        <li>Child in Gerudo Fortress is unbanned in all circumstances.</li>
+        <li>
+            Timing will end differently based on the gamemode:
+            <ol>
+                <li>If it is a “Beat Ganon” seed, standard timing rules apply; .done is on the first frame of the cutscene that plays after beating Ganon.</li>
+                <li>If it is a “Triforce Hunt” seed, .done will be on the first frame the game fades completely to black after obtaining the last required piece.</li>
+            </ol>
+        </li>
+    </ol>
 </div>

--- a/html_templates/rules_body.html
+++ b/html_templates/rules_body.html
@@ -1,0 +1,17 @@
+<div class="player-table">
+    <span class="table-header"><h4>Rules</h4></span>
+    <ol class="rules">
+    <li>You must use the <a href="https://github.com/matthewkirby/plando-random-settings/releases/latest">most recent version</a> of the RSL script. (Seeds rolled by RSLBot are always on the most recent version.)</li>
+    <li>You must ping <tt>@Random Settings</tt> in the OoTR Discord and have your race open to all participants.</li>
+    <li>Follow the <a href="https://wiki.ootrandomizer.com/index.php?title=Rules#Universal_Rules">Universal Rules</a> and the <a href="https://wiki.ootrandomizer.com/index.php?title=Standard">Standard</a> ruleset, with a few exceptions listed below:</li>
+    <li>Crossing the Gerudo Valley bridge as a child shall be banned unless it is from back to front.</li>
+    <li>Crossing the Gerudo Valley bridge as an adult shall be banned unless the bridge itself is repaired, or you have Epona or Longshot.</li>
+    <li>Child in Gerudo Fortress is unbanned in all circumstances.</li>
+    <li>Timing will end differently based on the gamemode:
+        <ol>
+            <li>If it is a “Beat Ganon” seed, standard timing rules apply; .done is on the first frame of the cutscene that plays after beating Ganon.</li>
+            <li>If it is a “Triforce Hunt” seed, .done will be on the first frame the game fades completely to black after obtaining the last required piece.</li>
+        </ol>
+    </li>
+</ol>
+</div>

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -27,7 +27,9 @@ header li {
     padding: 0;
 }
 
-header li:last-child {
+header li.right {
+    float: right;
+    border-left: 1px solid #d5d5d5;
     border-right: none;
 }
 
@@ -100,12 +102,16 @@ h3 {
     margin-inline-end: 0px;
 }
 
-a.table, a.materials {
+.rules {
+    padding: 5px 20px 5px 40px;
+}
+
+a.table, a.materials, .rules a {
     color: inherit;
     text-decoration: none;
 }
 
-a.table:hover, a.table:focus, a.materials:hover, a.materials:focus {
+a.table:hover, a.table:focus, a.materials:hover, a.materials:focus, .rules a {
     text-decoration: underline;
 }
 


### PR DESCRIPTION
This adds <https://rsl-leaderboard.web.app/rules> with racing rules taken from [the 2020-09-30 announcement](https://discord.com/channels/274180765816848384/704998001747165369/760971836946776084) and the Gameplay Rules section of [the S3 tournament rules](https://docs.google.com/document/d/1G3AIdYR3fOPLSlFa8U2OC7dVShtxs63lwcPZpomVmsc/edit). I omitted the last rule since it's tournament-specific afaik.