### PR TITLE
Remove redundant rules

### DIFF
--- a/html_templates/rules_body.html
+++ b/html_templates/rules_body.html
@@ -9,12 +9,7 @@
         You must ping <p class="monospace">@Random Settings</p> in the OoTR Discord and have your race open to all participants.
     </li>
     <li class="rules">
-        Follow the <a href="https://wiki.ootrandomizer.com/index.php?title=Rules#Universal_Rules">Universal Rules</a> and the <a href="https://wiki.ootrandomizer.com/index.php?title=Standard">Standard</a> ruleset, with a few exceptions listed below:
-        <ol>
-            <li>Crossing the Gerudo Valley bridge as a child shall be banned unless it is from back to front.</li>
-            <li>Crossing the Gerudo Valley bridge as an adult shall be banned unless the bridge itself is repaired, or you have Epona or Longshot.</li>
-            <li>Child in Gerudo Fortress is unbanned in all circumstances.</li>
-        </ol>
+        Follow the <a href="https://wiki.ootrandomizer.com/index.php?title=Rules#Universal_Rules">Universal Rules</a> and the <a href="https://wiki.ootrandomizer.com/index.php?title=Standard">Standard</a> ruleset.
     </li>
     <li class="rules">
         Timing will end differently based on the gamemode:


### PR DESCRIPTION
[This message in #racemod-general](https://discord.com/channels/274180765816848384/638167236389109790/1133203641503842364) points out that the Standard ruleset has been adjusted so the exceptions for RSL are no longer necessary:

* The rules around crossing Gerudo Valley have been reworded so crossing back to front as child is allowed anyway, so RSL no longer needs to make an exception for it
* The same rewording has also added the word “broken” so the exception for it already being repaired is no longer required
* The rule banning child in Gerudo Fortress depending on the settings was removed

This PR removes these exceptions from the rules page. The timing rules are still required since the category rules on [racetime.gg/ootr](https://racetime.gg/ootr) don't cover Triforce Hunt.